### PR TITLE
chore(general): clarifies installation and settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,24 @@ You can use software such as [stunnel](https://www.stunnel.org/) to achieve this
 
 ## Installation
 
- 1. Place the plugin source code to Elgg's `mod/` directory
+ 1. Place the plugin (it must be named `pusher`) in Elgg's `mod/` directory
  2. Enable the plugin form Elgg admin panel
  3. Enter plugin settings
  4. Flush Elgg caches
- 5. Enable the push server
-     - Example command on a Unix-like OS using the `nohup` command:
+ 5. Start the push server. E.g. `php -f /var/www/elgg/mod/pusher/push-server.php`
+ 6. Verify that logged in users receive real-time updates from plugins that have support
+    for the push server
+ 7. Stop and install the push server as a service (TODO)
 
-		```
-		nohup /usr/bin/php5 -f /var/www/elgg/mod/pusher/push-server.php
-		```
+## Notes
 
- 6. Logged in users should now receive real-time updates from plugins that have support for the push server
+`push-server.php` may run with different PHP settings. Make sure your Elgg `settings.php`
+file specifies the default timezone, and that Elgg does not emit warnings, notices, errors,
+or fatal exceptions on start up.
+
+If using PHP installed via Homebrew for Mac, you may need to install ZeroMQ and the PHP
+module from source:
+
+```
+brew install php56-zmq --universal --build-from-source
+```

--- a/languages/en.php
+++ b/languages/en.php
@@ -1,10 +1,12 @@
 <?php
 
 return array(
+	'pusher:settings:private_port:label' => 'Internal Web socket port',
+	'pusher:settings:private_port:desc' => 'The port to which the push server will listen for web socket connections.',
+
 	'pusher:settings:public_port:label' => 'Public web socket port',
-	'pusher:settings:public_port:desc' => 'The server port that clients will use to establish a websocket connection to the push server.',
-	'pusher:settings:private_port:label' => 'Private web socket port',
-	'pusher:settings:private_port:desc' => 'This allows you to define a separate port that the push server will listen to, if you are using a proxy to tunnel traffic from the public port. Enter the public web socket port, if proxy is not being used.',
+	'pusher:settings:public_port:desc' => 'Leave empty if your web socket port is public. If you are using a proxy to tunnel traffic, enter the external port clients must use.',
+
 	'pusher:settings:scheme:label' => 'URI scheme',
 	'pusher:settings:scheme:insecure' => 'ws:// (insecure)',
 	'pusher:settings:scheme:secure' => 'wss:// (secure)',

--- a/push-server.php
+++ b/push-server.php
@@ -6,8 +6,9 @@ require __DIR__ . '/vendor/autoload.php';
 // Start Elgg engine so we can access plugin settings
 $elgg = \Elgg\Application::start();
 
-// Get the websocket port from plugin settings
-$port = _elgg_services()->plugins->get('pusher')->getSetting('private_port');
+// Internal port for WS connections. Note: in case of proxy, clients will be connecting
+// to the external port (specified in the "public_port" setting).
+$ws_port = elgg_get_plugin_setting('private_port', 'pusher');
 
 $loop   = React\EventLoop\Factory::create();
 $pusher = new \Pusher\Server();
@@ -15,12 +16,18 @@ $pusher = new \Pusher\Server();
 // Listen for the web server to make a ZeroMQ push after a request
 $context = new React\ZMQ\Context($loop);
 $pull = $context->getSocket(ZMQ::SOCKET_PULL);
-$pull->bind('tcp://127.0.0.1:5555'); // Binding to 127.0.0.1 means the only client that can connect is itself
+
+// Binding to 127.0.0.1 means the only client that can connect is itself
+$pull->bind('tcp://127.0.0.1:5555');
+
 $pull->on('message', array($pusher, 'onZmqMessage'));
 
 // Set up our WebSocket server for clients wanting real-time updates
 $webSock = new React\Socket\Server($loop);
-$webSock->listen($port, '0.0.0.0'); // Binding to 0.0.0.0 means remotes can connect
+
+// Binding to 0.0.0.0 means remotes can connect
+$webSock->listen($ws_port, '0.0.0.0');
+
 $webServer = new Ratchet\Server\IoServer(
 	new Ratchet\Http\HttpServer(
 		new Ratchet\WebSocket\WsServer(

--- a/views/default/plugins/pusher/settings.php
+++ b/views/default/plugins/pusher/settings.php
@@ -4,25 +4,27 @@
  */
 
 $plugin = elgg_extract('entity', $vars);
-
-$public_port_label = elgg_echo('pusher:settings:public_port:label');
-$public_port_input = elgg_view('input/text', array(
-	'name' => 'params[public_port]',
-	'value' => $plugin->public_port,
-));
-$public_port_desc = elgg_echo('pusher:settings:public_port:desc');
+/* @var ElggPlugin $plugin */
 
 $private_port_label = elgg_echo('pusher:settings:private_port:label');
 $private_port_input = elgg_view('input/text', array(
 	'name' => 'params[private_port]',
-	'value' => $plugin->private_port,
+	'value' => $plugin->getSetting('private_port', '8099'),
+	'required' => true,
 ));
 $private_port_desc = elgg_echo('pusher:settings:private_port:desc');
+
+$public_port_label = elgg_echo('pusher:settings:public_port:label');
+$public_port_input = elgg_view('input/text', array(
+	'name' => 'params[public_port]',
+	'value' => $plugin->getSetting('public_port'),
+));
+$public_port_desc = elgg_echo('pusher:settings:public_port:desc');
 
 $scheme_label = elgg_echo('pusher:settings:scheme:label');
 $scheme_input = elgg_view('input/radio', array(
 	'name' => 'params[scheme]',
-	'value' => $plugin->scheme,
+	'value' => $plugin->getSetting('scheme'),
 	'options' => array(
 		elgg_echo('pusher:settings:scheme:secure') => 'wss://',
 		elgg_echo('pusher:settings:scheme:insecure') => 'ws://',
@@ -32,14 +34,14 @@ $scheme_desc = elgg_echo('pusher:settings:scheme:desc');
 
 echo <<<FORM
 	<div>
-		<label>$public_port_label</label>
-		$public_port_input
-		<p class="elgg-text-help">$public_port_desc</p>
-	</div>
-	<div>
 		<label>$private_port_label</label>
 		$private_port_input
 		<p class="elgg-text-help">$private_port_desc</p>
+	</div>
+	<div>
+		<label>$public_port_label</label>
+		$public_port_input
+		<p class="elgg-text-help">$public_port_desc</p>
 	</div>
 	<div>
 		<label>$scheme_label</label>

--- a/views/default/pusher/settings.js.php
+++ b/views/default/pusher/settings.js.php
@@ -4,6 +4,10 @@
  */
 
 $settings = elgg_get_plugin_from_id('pusher')->getAllSettings();
+if (empty($settings['public_port'])) {
+	$settings['public_port'] = elgg_extract('private_port', $settings);
+}
+
 $settings = array(
     'scheme' => elgg_extract('scheme', $settings),
     'port' => elgg_extract('public_port', $settings),


### PR DESCRIPTION
Swaps settings order and gives them clearer names and descriptions.
Makes public port optional.
Removes mention of `nohup` since this doesn't seem like a realistic production solution.
